### PR TITLE
Managers chat

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,7 +40,7 @@ model User {
 
   // Self relation: Managers belong to a hospital
   hospitalId          String?   
-  hospital            User?     @relation("HospitalManagers", fields: [hospitalId], references: [id])
+  hospital            User?     @relation("HospitalManagers", fields: [hospitalId], references: [id], onDelete: Cascade)
   managers            User[]    @relation("HospitalManagers")
 
   documents Document[]
@@ -59,7 +59,7 @@ model Patient {
   fileName      String?
   hospitalUserId String?
   createdAt     DateTime @default(now())
-  hospital User? @relation(fields: [hospitalUserId], references: [id])
+  hospital User? @relation(fields: [hospitalUserId], references: [id], onDelete: SetNull)
   insuranceRequests InsuranceRequest[]
 }
 
@@ -117,7 +117,7 @@ model InsuranceRequest {
   comments    Comment[]
   documents   Document[]
   queries     Query[]
-  user     User?  @relation(fields: [assignedTo], references: [id])
+  assignee     User?  @relation(fields: [assignedTo], references: [id])
   patient     Patient  @relation(fields: [patientId], references: [id])
 }
 
@@ -170,7 +170,7 @@ model Comment {
   isRead      Boolean  @default(false)
   createdBy   String?
   createdAt   DateTime @default(now())
-  hospital    User?  @relation("HospitalComments", fields: [hospitalId], references: [id])
+  hospital    User?  @relation("HospitalComments", fields: [hospitalId], references: [id], onDelete: SetNull)
   creator    User?    @relation(fields: [createdBy], references: [id], onDelete: SetNull)
   insuranceRequest InsuranceRequest? @relation(fields: [insuranceRequestId], references: [id])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,11 +37,18 @@ model User {
   tokens String[] @default([])
   createdAt DateTime @default(now()) 
   updatedAt DateTime @updatedAt 
+
+  // Self relation: Managers belong to a hospital
+  hospitalId          String?   
+  hospital            User?     @relation("HospitalManagers", fields: [hospitalId], references: [id])
+  managers            User[]    @relation("HospitalManagers")
+
   documents Document[]
   comments Comment[]
   notifications Notification[]
   insuranceRequests InsuranceRequest[]
   patients Patient[]
+  commentsForHospital Comment[] @relation("HospitalComments")
 } 
 
 model Patient {
@@ -62,15 +69,15 @@ model Document {
   fileName    String
   type        DocumentType
   remark      String?
-  uploadedBy  String
-  insuranceRequestId String
+  uploadedBy  String?
+  insuranceRequestId String?
   enhancementId String?
   queryId String?
   uploadedAt  DateTime @default(now())
-  uploader    User    @relation(fields: [uploadedBy], references: [id])
-  insuranceRequest InsuranceRequest? @relation(fields: [insuranceRequestId], references: [id])
-  enhancement Enhancement? @relation(fields: [enhancementId], references: [id])
-  query Query? @relation(fields: [queryId], references: [id])
+  uploader    User?    @relation(fields: [uploadedBy], references: [id], onDelete: SetNull)
+  insuranceRequest InsuranceRequest? @relation(fields: [insuranceRequestId], references: [id], onDelete: SetNull)
+  enhancement Enhancement? @relation(fields: [enhancementId], references: [id], onDelete: SetNull)
+  query Query? @relation(fields: [queryId], references: [id], onDelete: SetNull)
 }
 
 enum DocumentType {
@@ -158,10 +165,12 @@ model Comment {
   text        String
   type        CommentType
   insuranceRequestId String?
+  hospitalId  String?
   fileUrl     String?
-  createdBy   String
+  createdBy   String?
   createdAt   DateTime @default(now())
-  creator    User    @relation(fields: [createdBy], references: [id])
+  hospital    User?  @relation("HospitalComments", fields: [hospitalId], references: [id])
+  creator    User?    @relation(fields: [createdBy], references: [id], onDelete: SetNull)
   insuranceRequest InsuranceRequest? @relation(fields: [insuranceRequestId], references: [id])
 }
 
@@ -179,7 +188,7 @@ model Notification {
   message    String
   isRead     Boolean  @default(false)
   createdAt  DateTime @default(now())
-  user       User     @relation(fields: [userId], references: [id])
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model ActivityLog {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,6 +167,7 @@ model Comment {
   insuranceRequestId String?
   hospitalId  String?
   fileUrl     String?
+  isRead      Boolean  @default(false)
   createdBy   String?
   createdAt   DateTime @default(now())
   hospital    User?  @relation("HospitalComments", fields: [hospitalId], references: [id])

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
-import { $Enums, Prisma } from '@prisma/client';
+import { Prisma, Role } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { AuthResponse } from './dto/auth-response.dto';
 
@@ -15,16 +15,24 @@ export class AuthService {
     async validateUser(email: string, pass: string) {
         const user =  await this.prisma.user.findUnique({
             where: { email: email.toLowerCase() },
+            select: {
+                id: true,
+                name: true,
+                password: true,
+                email: true,
+                role: true,
+                hospitalId: true
+            }
         });
         if (!user) throw new UnauthorizedException('Invalid credentials');
 
         const passwordValid = await bcrypt.compare(pass, user.password);
         if (!passwordValid) throw new UnauthorizedException('Invalid credentials');
-
-        return { id: user.id, name: user.name, email: user.email , role: user.role };
+        const { password, ...rest } = user
+        return { ...rest };
     }
 
-    async generateAndStoreToken(user: { id: string, name: string, email: string, role: $Enums.Role}) {
+    async generateAndStoreToken(user: { id: string, name: string, email: string, role: Role }) {
         const payload = { sub: user.id, email: user.email, role: user.role }
         const token = await this.jwtService.signAsync(payload)
         if(!token) throw new UnauthorizedException('Failed to generate token!');

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -3,6 +3,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { ConfigService } from '@nestjs/config';
+import { Role } from '@prisma/client';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -27,7 +28,17 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (!user || !token || !user.tokens.includes(token)) {
       throw new UnauthorizedException('Token is not recognized or has expired');
     }   
-  
-    return { userId: payload.sub, email: payload.email, name: user.name, role: payload.role };
+
+    const result: any = {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+    };
+    if (user.role === Role.HOSPITAL_MANAGER) {
+      result.hospitalId = user.hospitalId;
+    }
+    
+    return result;
   }
 }

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -19,8 +19,8 @@ export class CommentsController {
   @ApiResponse({ status: 201, description: 'Comment created successfully.' })
   @ApiResponse({ status: 400, description: 'Bad Request' })
   create(@Request() req, @Body() data: CreateCommentsDto): Promise<Comment> {
-    const { userId:createdBy, role } = req.user;
-    return this.commentsService.create(role, data, createdBy)
+    const { userId:createdBy, role, hospitalId:loggedInUserHospitalId } = req.user;
+    return this.commentsService.create(role, data, createdBy, loggedInUserHospitalId)
   }
 
   @Get()
@@ -37,40 +37,66 @@ export class CommentsController {
       insuranceRequestId, createdBy,
       hospitalId
     } = query;
-    const allowedTypes: Record<Role, CommentType[]> = {
-      SUPER_ADMIN: ['NOTE', 'QUERY', 'TPA_REPLY', 'HOSPITAL_NOTE','SYSTEM'],
-      ADMIN: ['NOTE', 'QUERY', 'TPA_REPLY', 'HOSPITAL_NOTE', 'SYSTEM'],
-      HOSPITAL_MANAGER: ['NOTE', 'QUERY', 'TPA_REPLY', 'HOSPITAL_NOTE', 'SYSTEM'],
-      HOSPITAL: ['NOTE','QUERY', 'TPA_REPLY','SYSTEM'],
-    };
-
-    if(hospitalId && role===Role.HOSPITAL) throw new BadRequestException(`Permission Denied for ${role}`)
+    let hospitalIdForWhereClause:string
+    const isHospitalIdInQuery = hospitalId ? true : false
+    // const allowedTypes: Record<Role, CommentType[]> = {
+    //   SUPER_ADMIN: ['NOTE', 'QUERY', 'TPA_REPLY', 'HOSPITAL_NOTE','SYSTEM'],
+    //   ADMIN: ['NOTE', 'QUERY', 'TPA_REPLY', 'HOSPITAL_NOTE', 'SYSTEM'],
+    //   HOSPITAL_MANAGER: ['NOTE', 'QUERY', 'TPA_REPLY', 'HOSPITAL_NOTE', 'SYSTEM'],
+    //   HOSPITAL: ['NOTE','QUERY', 'TPA_REPLY','SYSTEM'],
+    // };
+    // assign hospitalId wise filter
+    if(role === Role.HOSPITAL) hospitalIdForWhereClause = currentUserId
+    else if (role === Role.HOSPITAL_MANAGER) {
+      if(!loggedInUserHospitalId) throw new BadRequestException(`Assign Hospital first for role ${role}`)
+      hospitalIdForWhereClause = loggedInUserHospitalId
+    }
+    else if(role===Role.ADMIN||role===Role.SUPER_ADMIN) hospitalIdForWhereClause = hospitalId
+    
+    if(role===Role.HOSPITAL){
+      if(!insuranceRequestId) {
+        throw new BadRequestException(`insuranceRequestId/claim uuid is required in query param for Role ${role}`)
+      }
+      if(hospitalId) {
+        throw new BadRequestException(`Role ${role} can only access claim comments`)
+      }
+    }
 
     const where: Prisma.CommentWhereInput = {
       ...(insuranceRequestId && { insuranceRequestId }),
       ...(createdBy && { createdBy }),
-      ...((hospitalId && role !== Role.HOSPITAL) && { hospitalId }) ,
-      type: { in: allowedTypes[role] },
+      ...(hospitalIdForWhereClause && { hospitalId: hospitalIdForWhereClause }) ,
+      ...(isHospitalIdInQuery && { type: CommentType.HOSPITAL_NOTE })
+      // type: { in: allowedTypes[role] },
     };
 
-    return this.commentsService.findAll({ take, cursor, where, currentUserId, role, loggedInUserHospitalId });
+    return this.commentsService.findAll({ 
+      take, cursor, where, 
+      currentUserId, role, 
+      loggedInUserHospitalId
+    });
   }
 
-  @Patch('mark-read/:hospitalId')
+  @Patch('markRead/:hospitalId')
   @ApiOperation({ summary: 'Mark all unread comments from a hospital as read' })
   markRead(
     @Param('hospitalId') hospitalId: string,
     @Request() req
   ) {
+    const { userId: currentUserId, role } = req.user;
+    // only admin and superadmin can mark
+    if(role===Role.HOSPITAL||role===Role.HOSPITAL_MANAGER) throw new BadRequestException(`Role ${role} not allowed!`)
     if(!hospitalId) throw new BadRequestException("hospitalId is required in query!");
-    const { userId: currentUserId } = req.user;
     return this.commentsService.markRead(hospitalId, currentUserId);
   }
 
   @Get('/list_manager_comments')
   @ApiOperation({ summary: 'Get all active chats' })
   @ApiResponse({ status: 200, description: 'List of chats' })
-  listHospitalsWithManagerComments() {
+  listHospitalsWithManagerComments(@Request() req) {
+    const { role } = req.user;
+    // only admin and superadmin can mark
+    if(role===Role.HOSPITAL||role===Role.HOSPITAL_MANAGER) throw new BadRequestException(`Role ${role} not allowed!`)
     return this.commentsService.listHospitalsWithManagerComments()
   }
 

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,14 +1,24 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateCommentsDto } from './dto/create-comments.dto';
-import { Comment, CommentType, Prisma } from '@prisma/client';
+import { Comment, CommentType, Prisma, Role } from '@prisma/client';
 
 @Injectable()
 export class CommentsService {
     constructor(private prisma: PrismaService) {}
     
-     async create(data: CreateCommentsDto, createdBy: string): Promise<Comment> {
+     async create(
+        role: string,
+        data: CreateCommentsDto, 
+        createdBy: string
+    ): Promise<Comment> {
         const { insuranceRequestId, hospitalId, ...rest } = data;
+        if(role === Role.HOSPITAL && data.type===CommentType.HOSPITAL_NOTE) {
+            throw new BadRequestException(`Role ${role} can't post manager comments`)
+        }
+        if(insuranceRequestId && hospitalId) {
+            throw new BadRequestException("insuranceRequestId and hospitalId both can't be used at same time.")
+        }
         if(rest.type === CommentType.NOTE || 
         rest.type === CommentType.QUERY || 
         rest.type === CommentType.TPA_REPLY) {
@@ -23,6 +33,7 @@ export class CommentsService {
             ...rest, 
             ...(hospitalId ? { hospital: { connect: { id: hospitalId }}} : undefined), 
             ...(insuranceRequestId ? { insuranceRequest: { connect: { id: insuranceRequestId }}} : undefined), 
+            ...(insuranceRequestId && { isRead: true }),
             creator: { connect: { id: createdBy }} 
           }
         });
@@ -32,50 +43,83 @@ export class CommentsService {
         take?: number;
         cursor?: string;
         where?: Prisma.CommentWhereInput;
+        currentUserId: string,
+        role: Role,
+        loggedInUserHospitalId: string
     }): Promise<Comment[]> {
-        const { cursor, take, where } = params;
-        return await this.prisma.comment.findMany({
+        const { cursor, take, where, currentUserId, role, loggedInUserHospitalId } = params;
+        const comments = this.prisma.comment.findMany({
             take,
             ...(cursor && { cursor: { id: cursor }, skip: 1 }),
             where,
             orderBy: { createdAt: 'desc' },
             include: {
-                creator: { select: { id: true, name: true } },
+                creator: { select: { id: true, name: true, profileUrl: true } },
             },
         })
+        if (role === Role.HOSPITAL_MANAGER && loggedInUserHospitalId) {
+            await this.prisma.comment.updateMany({
+                where: {
+                    hospitalId: loggedInUserHospitalId,
+                    isRead: false,
+                    createdBy: { not: currentUserId },
+                },
+                data: { isRead: true },
+            });
+        }
+
+        return comments
     }
 
-    async listHospitalsWithManagerComments() {
-        return await this.prisma.user.findMany({
-            where: { 
-                role: 'HOSPITAL' ,
-                managers: {
-                    some: {
-                        comments: {
-                            some: { type: 'HOSPITAL_NOTE' }
-                        }
-                    }
-                }
+    async markRead(hospitalId: string, currentUserId: string) {
+        return await this.prisma.comment.updateMany({
+            where: {
+                hospitalId,
+                isRead: false,
+                createdBy: { not: currentUserId },
             },
-            select: {
-                id: true,
-                name: true,
-                managers: {
-                    select: {
-                        id: true,
-                        name: true,
-                        hospital: {
-                            select : { id: true, name: true }
-                        },
-                        comments: {
-                            where: { type: 'HOSPITAL_NOTE' },
-                            orderBy: { createdAt: 'desc' },
-                            take: 1, // latest comment
-                            select: { createdAt: true }
-                        }
-                    }
-                }
-            }
+            data: { isRead: true },
         });
+    }
+
+
+    async listHospitalsWithManagerComments() {
+        const latestComments: Comment[] = await this.prisma.$queryRaw`
+            SELECT DISTINCT ON ("hospitalId") c."id", c."text", c."type", c."hospitalId", c."createdAt",
+                    h."name" as "hospitalName",
+                    u."name" as "creatorName"
+            FROM "Comment" c
+            LEFT JOIN "User" h ON h."id" = c."hospitalId"
+            LEFT JOIN "User" u ON u."id" = c."createdBy"
+            WHERE c."type" = 'HOSPITAL_NOTE'
+            ORDER BY c."hospitalId", c."createdAt" DESC
+        `;
+        // make global sorting desc for comment list
+        return latestComments.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+        // Get latest comment timestamp per hospital
+        // const latestPerHospital = await this.prisma.comment.groupBy({
+        //     by: ['hospitalId'],
+        //     where: { type: 'HOSPITAL_NOTE' },
+        //     _max: { createdAt: true }
+        // });
+        // return await this.prisma.comment.findMany({
+        //     where: {
+        //         type: 'HOSPITAL_NOTE',
+        //         OR: latestPerHospital.map(l => ({
+        //         hospitalId: l.hospitalId,
+        //         createdAt: l._max.createdAt
+        //         }))
+        //     },
+        //     select: {
+        //         id: true,
+        //         text: true,
+        //         type: true,
+        //         hospitalId: true,
+        //         hospital: { select: { id: true, name: true }},
+        //         creator: { select: { id: true, name: true }}
+        //     },
+        //     orderBy: { createdAt: 'desc' }
+        // });
+
     }
 }

--- a/src/comments/dto/create-comments.dto.ts
+++ b/src/comments/dto/create-comments.dto.ts
@@ -1,21 +1,51 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { CommentType } from "@prisma/client";
-import { IsEnum, IsOptional, IsString } from "class-validator";
+import { IsEnum, IsIn, IsOptional, IsString, ValidateIf } from "class-validator";
 
 export class CreateCommentsDto {
     @ApiProperty({ example: 'comments-uuid'})
     @IsString()
     text: string;
 
-    @ApiProperty({ example: CommentType.QUERY })
+    @ApiProperty({ 
+        example: CommentType.QUERY,
+        enum: CommentType,
+        description: 'SYSTEM is excluded from API-created comments', 
+    })
     @IsEnum(CommentType)
+    @IsIn([
+        CommentType.NOTE,
+        CommentType.QUERY,
+        CommentType.TPA_REPLY,
+        CommentType.HOSPITAL_NOTE,
+    ], { message: 'SYSTEM comments cannot be created manually' })
     type: CommentType;
 
-    @ApiProperty({ example: 'insuranceRequest-uuid'})
-    @IsString()
-    insuranceRequestId: string;
+    @ApiProperty({ 
+        example: 'insuranceRequest-uuid', 
+        required: false,
+        description: 'Required for claim based commenttypes NOTE, TPA_REPLY, QUERY'
+    })
+    @ValidateIf(o => o.type !== CommentType.HOSPITAL_NOTE)
+    @IsString({ 
+        message: 'insuranceRequestId must be provided unless type is HOSPITAL_NOTE' 
+    })
+    insuranceRequestId?: string;
+    
+    // @ApiProperty({ example: 'insuranceRequest-uuid'})
+    // @IsString()
+    // insuranceRequestId: string;
+    @ApiProperty({ 
+        example: 'hospital-uuid', 
+        required: false,
+        description: 'Required if type is HOSPITAL_NOTE'
+    })
+    @ValidateIf(o => o.type === CommentType.HOSPITAL_NOTE)
+    @IsString({ message: 'hospitalId must be provided if type is HOSPITAL_NOTE' })
+    hospitalId?: string;
+
         
-    @ApiProperty({ example: 'https://example.com/folder/fileName.pdf'})
+    @ApiPropertyOptional({ example: 'https://example.com/folder/fileName.pdf'})
     @IsOptional()
     @IsString()
     fileUrl?: string;

--- a/src/comments/dto/create-comments.dto.ts
+++ b/src/comments/dto/create-comments.dto.ts
@@ -38,7 +38,7 @@ export class CreateCommentsDto {
     @ApiProperty({ 
         example: 'hospital-uuid', 
         required: false,
-        description: 'Required if type is HOSPITAL_NOTE'
+        description: 'Required for manager level comments'
     })
     @ValidateIf(o => o.type === CommentType.HOSPITAL_NOTE)
     @IsString({ message: 'hospitalId must be provided if type is HOSPITAL_NOTE' })

--- a/src/comments/dto/find-all-comments.dto.ts
+++ b/src/comments/dto/find-all-comments.dto.ts
@@ -31,6 +31,7 @@ export class FindAllCommentsDto extends PaginationDto {
   createdBy?: string;
 
   @ApiPropertyOptional({ enum: Role })
+  @IsOptional()
   @IsEnum(Role)
   role?: Role;
 }

--- a/src/comments/dto/find-all-comments.dto.ts
+++ b/src/comments/dto/find-all-comments.dto.ts
@@ -9,17 +9,28 @@ export class FindAllCommentsDto extends PaginationDto {
   @IsEnum(CommentType)
   type?: CommentType;
 
-  @ApiPropertyOptional({ example: 'insuranceRequest-uuid' })
+  @ApiPropertyOptional({ 
+    example: 'insuranceRequest-uuid',
+    description: "Required for claim level comments list" 
+  })
   @IsOptional()
   @IsString()
   insuranceRequestId?: string;
+
+  @ApiPropertyOptional({ 
+    example: 'hospital-uuid',
+    description: "Required for manager level comments list" 
+  })
+  @IsOptional()
+  @IsString()
+  hospitalId?: string;
 
   @ApiPropertyOptional({ example: 'user-uuid' })
   @IsOptional()
   @IsString()
   createdBy?: string;
 
-  @ApiProperty({ enum: Role })
+  @ApiPropertyOptional({ enum: Role })
   @IsEnum(Role)
-  role: Role;
+  role?: Role;
 }

--- a/src/common/common.service.ts
+++ b/src/common/common.service.ts
@@ -25,16 +25,19 @@ export class CommonService {
         userId: string,
         notifiedTo: string,
         insuranceRequestId: string,
+        hospitalId: string,
         message: string
     }) {
-        const { userId, notifiedTo, insuranceRequestId, message } = params
+        const { userId, notifiedTo, insuranceRequestId, hospitalId, message } = params
         const [comment, activityLog] = await this.prisma.$transaction([
             this.prisma.comment.create({
                 data: {
                     text: message,
                     type: 'SYSTEM',
                     insuranceRequest: { connect: { id: insuranceRequestId }}, 
-                    creator: { connect: { id: userId }}
+                    hospital: { connect: { id: hospitalId }},
+                    creator: { connect: { id: userId }},
+                    isRead: true
                 },
             }),
             this.prisma.activityLog.create({

--- a/src/insurance-requests/insurance-requests.controller.ts
+++ b/src/insurance-requests/insurance-requests.controller.ts
@@ -37,11 +37,15 @@ export class InsuranceRequestsController {
     @Request() req,
     @Query() query: FindAllInsuranceRequestDto
   ): Promise<PaginatedResult<InsuranceRequest>> {
-    const { userId:hospitalUserId, role } = req.user
+    const { userId, role, hospitalId } = req.user
     const { skip, take, sortBy, sortOrder, 
       refNumber, doctorName, insuranceCompany, tpaName, assigneeName,
       patientName, status, createdFrom, createdTo
     } = query;
+    let hospitalUserId:string
+
+    if(role===Role.HOSPITAL) hospitalUserId = userId
+    else if(role===Role.HOSPITAL_MANAGER) hospitalUserId = hospitalId
 
     const where: Prisma.InsuranceRequestWhereInput = {};
     if(![Role.SUPER_ADMIN, Role.ADMIN].includes(role)) where.patient = { hospitalUserId }

--- a/src/insurance-requests/insurance-requests.controller.ts
+++ b/src/insurance-requests/insurance-requests.controller.ts
@@ -53,7 +53,7 @@ export class InsuranceRequestsController {
     if (doctorName) where.doctorName = { contains: doctorName, mode: 'insensitive' };
     if (insuranceCompany) where.insuranceCompany = { contains: insuranceCompany, mode: 'insensitive' };
     if (tpaName) where.tpaName = { contains: tpaName, mode: 'insensitive' };
-    if (assigneeName) where.user = { name: { contains: assigneeName, mode: 'insensitive' }};
+    if (assigneeName) where.assignee = { name: { contains: assigneeName, mode: 'insensitive' }};
     if (patientName) where.patient = { name: { contains: patientName, mode: 'insensitive' }};
     if (status  && status.length > 0) where.status = { in: status };
     if (createdFrom || createdTo) {

--- a/src/insurance-requests/insurance-requests.controller.ts
+++ b/src/insurance-requests/insurance-requests.controller.ts
@@ -125,8 +125,7 @@ export class InsuranceRequestsController {
   @ApiOperation({ summary: 'Delete insurance request by ref number' })
   @ApiParam({ name: 'refNumber', example: 'CLM-00001' })
   remove(@Param('refNumber') refNumber: string) {
-    // return this.insuranceRequestsService.remove(refNumber);
-    return "This is remove claim"
+    return this.insuranceRequestsService.remove(refNumber);
   }
 }
  

--- a/src/insurance-requests/insurance-requests.service.ts
+++ b/src/insurance-requests/insurance-requests.service.ts
@@ -56,11 +56,12 @@ export class InsuranceRequestsService {
         refNumber 
       },
       include: { 
-        patient: { select: { id: true, name: true }}
+        patient: { select: { id: true, name: true, hospital: { select: { id: true }} }}
       }
     });
 
     if(!createdClaim) throw new BadRequestException("Failed to create claim!")
+    const patientHospitalId = createdClaim.patient.hospital.id
 
     // notify to super admin
     await this.commonService.logInsuranceRequestNotification({
@@ -86,6 +87,7 @@ export class InsuranceRequestsService {
       userId: uploadedBy,
       notifiedTo: isSuperAdminExists.id,
       insuranceRequestId: createdClaim.id,
+      hospitalId: patientHospitalId,
       message: `${userName} uploaded ${createdDocuments.length} document(s) for ${refNumber}`,
     });
   
@@ -267,11 +269,12 @@ export class InsuranceRequestsService {
           ...(patientId && { patient: { connect: { id: patientId } } })
         },
         include: {
-          patient: { select: { id: true, name: true }},
+          patient: { select: { id: true, name: true, hospital: { select: { id: true }}}},
         },
       });
 
       if(!updatedClaim) throw new BadRequestException("Failed to update claim!")
+      const patientHospitalId = updatedClaim.patient.hospital.id
 
       await this.commonService.logActivity(
         uploadedBy,
@@ -285,6 +288,7 @@ export class InsuranceRequestsService {
           userId: uploadedBy,
           notifiedTo: assigneeId,
           insuranceRequestId: claimExists.id,
+          hospitalId: patientHospitalId,
           message: `${userName} updated status from ${claimExists.status} to ${data.status} for ${updatedClaim.refNumber}`,
         });
       }
@@ -310,6 +314,7 @@ export class InsuranceRequestsService {
             userId: uploadedBy,
             notifiedTo: assigneeId,
             insuranceRequestId: updatedClaim.id,
+            hospitalId: patientHospitalId,
             message:`${userName} added ${createdDocuments.length} document(s) for ${updatedClaim.refNumber}`,
           });
         }
@@ -338,6 +343,7 @@ export class InsuranceRequestsService {
             userId: uploadedBy,
             notifiedTo: assigneeId,
             insuranceRequestId: updatedClaim.id,
+            hospitalId: patientHospitalId,
             message:`${userName} modified ${updatedDocuments.length} document(s) for ${updatedClaim.refNumber}`,
           });
         }

--- a/src/insurance-requests/insurance-requests.service.ts
+++ b/src/insurance-requests/insurance-requests.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { CreateInsuranceRequestDto } from './dto/create-insurance-request.dto';
 import { UpdateInsuranceRequestDto } from './dto/update-insurance-request.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { Document, InsuranceRequest, Prisma, Role } from '@prisma/client';
+import { ClaimStatus, Document, InsuranceRequest, Prisma, Role } from '@prisma/client';
 import { PaginatedResult } from 'src/common/interfaces/paginated-result.interface';
 import { DocumentResponseDto, MutateResponseInsuranceRequestDto } from './dto/mutate-response-insurance-requests.dto';
 import { FileService } from 'src/file/file.service';
@@ -354,8 +354,10 @@ export class InsuranceRequestsService {
     }
   
     async remove(refNumber: string): Promise<InsuranceRequest>{
-      return await this.prisma.insuranceRequest.delete({
-        where: { refNumber }
+      const result = await this.prisma.insuranceRequest.delete({
+        where: { refNumber, status: ClaimStatus.DRAFT }
       })
+      if(!result) throw new BadRequestException("Record not found OR it was not a DRAFT status claim")
+      return result
     }
 }

--- a/src/insurance-requests/insurance-requests.service.ts
+++ b/src/insurance-requests/insurance-requests.service.ts
@@ -353,11 +353,11 @@ export class InsuranceRequestsService {
       };
     }
   
-    async remove(refNumber: string): Promise<InsuranceRequest>{
-      const result = await this.prisma.insuranceRequest.delete({
+    async remove(refNumber: string): Promise<Number>{
+      const result = await this.prisma.insuranceRequest.deleteMany({
         where: { refNumber, status: ClaimStatus.DRAFT }
       })
-      if(!result) throw new BadRequestException("Record not found OR it was not a DRAFT status claim")
-      return result
+      if(result.count === 0) throw new BadRequestException("Record not found OR it was not a DRAFT status claim")
+      return result.count
     }
 }

--- a/src/patients/patients.module.ts
+++ b/src/patients/patients.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PatientsService } from './patients.service';
 import { PatientsController } from './patients.controller';
+import { FileModule } from 'src/file/file.module';
 
 @Module({
+  imports:[FileModule],
   controllers: [PatientsController],
   providers: [PatientsService],
 })

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { ClaimStatus, Patient, Prisma, Role } from '@prisma/client';
 import { CreatePatientDto } from './dto/create-patient.dto';
@@ -98,7 +98,7 @@ export class PatientsService {
     hospitalUserId: string 
   }): Promise<Patient>{
     const claimsCount = await this.prisma.insuranceRequest.count({ where: { patientId: where.id } });
-    if (claimsCount>0) throw new Error("Cannot delete patient with existing claims");
+    if (claimsCount>0) throw new BadRequestException("Cannot delete patient with existing claims");
     return await this.prisma.patient.delete({
       where
     })

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -97,6 +97,8 @@ export class PatientsService {
     id: string; 
     hospitalUserId: string 
   }): Promise<Patient>{
+    const claimsCount = await this.prisma.insuranceRequest.count({ where: { patientId: where.id } });
+    if (claimsCount>0) throw new Error("Cannot delete patient with existing claims");
     return await this.prisma.patient.delete({
       where
     })

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -2,10 +2,14 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { ClaimStatus, Patient, Prisma, Role } from '@prisma/client';
 import { CreatePatientDto } from './dto/create-patient.dto';
+import { FileService } from 'src/file/file.service';
 
 @Injectable()
 export class PatientsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+     private fileService: FileService
+  ) {}
 
   async create(
     data: CreatePatientDto,
@@ -97,10 +101,15 @@ export class PatientsService {
     id: string; 
     hospitalUserId: string 
   }): Promise<Patient>{
-    const claimsCount = await this.prisma.insuranceRequest.count({ where: { patientId: where.id } });
+    const claimsCount = await this.prisma.insuranceRequest.count({ 
+      where: { patientId: where.id } 
+    });
     if (claimsCount>0) throw new BadRequestException("Cannot delete patient with existing claims");
-    return await this.prisma.patient.delete({
+    
+    const result = await this.prisma.patient.delete({
       where
     })
+    if(result.fileName) await this.fileService.deleteFile(result.fileName)
+    return result
   }
 }

--- a/src/users/dto/create-users.dto.ts
+++ b/src/users/dto/create-users.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsEnum, IsOptional, IsString, MinLength, ValidateIf } from 'class-validator';
+import { IsEmail, IsEnum, IsIn, IsOptional, IsString, MinLength, ValidateIf } from 'class-validator';
 import { Role } from '@prisma/client';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
@@ -56,5 +56,10 @@ export class CreateUserDto {
 
     @ApiProperty({ enum: Role, example: Role.HOSPITAL })
     @IsEnum(Role)
+    @IsIn([
+        Role.ADMIN,
+        Role.HOSPITAL,
+        Role.HOSPITAL_MANAGER,
+    ], { message: 'SUPERADMIN cannot be created manually' })
     role: Role; 
 }

--- a/src/users/dto/create-users.dto.ts
+++ b/src/users/dto/create-users.dto.ts
@@ -1,8 +1,17 @@
-import { IsEmail, IsEnum, IsOptional, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsEnum, IsOptional, IsString, MinLength, ValidateIf } from 'class-validator';
 import { Role } from '@prisma/client';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateUserDto {
+    @ApiProperty({ 
+        example: 'hospital-user-uuid', 
+        required: false,
+        description: 'Required if role is HOSPITAL_MANAGER'
+    })
+    @ValidateIf(o => o.role === Role.HOSPITAL_MANAGER)
+    @IsString({ message: 'hospitalId must be provided if role is HOSPITAL_MANAGER' })
+    hospitalId?: string;
+
     @ApiProperty({ example: 'John Doe' })
     @IsString()
     name: string;
@@ -36,9 +45,14 @@ export class CreateUserDto {
     @IsString()
     address?: string;
 
-    @ApiProperty({ example: 'hospitals/fileName.pdf' })
-    @IsString()
-    rateListFileName: string;
+    @ApiProperty({ 
+        example: 'hospitals/fileName.pdf',
+        required: false,
+        description: 'Required if role is HOSPITAL'
+    })
+    @ValidateIf(o => o.role === Role.HOSPITAL)
+    @IsString({ message: 'rateListFileName must be provided if role is HOSPITAL' })
+    rateListFileName?: string;
 
     @ApiProperty({ enum: Role, example: Role.HOSPITAL })
     @IsEnum(Role)

--- a/src/users/dto/find-all-users.dto.ts
+++ b/src/users/dto/find-all-users.dto.ts
@@ -1,5 +1,5 @@
 import { Role } from "@prisma/client";
-import { IsEnum, IsOptional, IsString } from "class-validator";
+import { IsEnum, IsIn, IsOptional, IsString } from "class-validator";
 import { PaginationDto } from "common/dto/pagination.dto"
 
 export class FindAllUserDto extends PaginationDto {
@@ -13,5 +13,10 @@ export class FindAllUserDto extends PaginationDto {
 
     @IsOptional()
     @IsEnum(Role)
+    @IsIn([
+        Role.ADMIN,
+        Role.HOSPITAL,
+        Role.HOSPITAL_MANAGER,
+    ], { message: 'SUPERADMIN cannot be created manually' })
     role?: Role;
 }


### PR DESCRIPTION
FIRST COMMIT
1- ADDED schema for Cascade Rules of Patient, Claims, and User's onDelete reference
2- ADDED hospitalId in comments, Self referencing hospitalId for HOSPITAL_MANAGER roles for manager's chats.
3- UPDATED comments create, and listing for posting and fetching manager level comments.
4- ADDED API to fetch chat list for ADMIN side UI.
5- ADDED Patient delete if no claims are associated and Claim delete if status is DRAFT on Delete API.

SECOND COMMIT
1- ADDED isRead to comment schema, ADDED hospitalId in auth user for HOSPITAL_MANAGER role.
2- ADDED direct isRead for claim based and HOSPITAL_MANAGER comment post.
3- ADDED conditional based create and read for claim and manager level comments. 
4- ADDED bulk read comments API for ADMIN on any hospital detail chat.
5- ADDED marking auto isRead for HOSPITAL_MANAGER on manager level chats. 
6- UPDATED ADMIN side active chats list with global sorting.
7- FIXED delete claim for DRAFT status.
8- ADDED validation for condtionally adding hospitalId for HOSPITAL_MANAGER roles. 
9- ADDED conditional based payload validation for users, and comments.

THIRD COMMIT
1- ADDED hospitalId for login auth response.
2- ADDED hospitalId required of comment.
3- UPDATED comment creation manual and System with hospitalId.
4- ADDED filter for Roles on Comment List.
5- UPDATED markRead to validate hospitalId. 
5- ADDED unRead counts of ADMIN side manager list UI.

FOURTH COMMIT
1- ADDED documents deletion for DRAFT status claims and Patient profiles if present.

FIFTH COMMIT
1- ADDED onDelete rules for HOSPITAL to setNull its associated Patients, Comments, and direct delete its managers.
2- ADDED assigneeName in claim list response.
3- UPDATED delete draft claims along with its documents and S3.
4- ADDED restrictions to any modification for SUPERADMIN account.
5- ADDED S3 file clear on User delete
